### PR TITLE
Fix bug in calculation of off-diagonal terms of Smag parameterisation

### DIFF
--- a/torch_qg/parameterizations.py
+++ b/torch_qg/parameterizations.py
@@ -50,7 +50,7 @@ class Smagorinsky():
         vh=ik*ph
         Sxx = torch.fft.irfftn(uh*ik,dim=(1,2))
         Syy = torch.fft.irfftn(vh*il,dim=(1,2))
-        Sxy = 0.5 * torch.fft.irfftn(uh * il + vh * ik)
+        Sxy = 0.5 * torch.fft.irfftn(uh * il + vh * ik,dim=(1,2))
         nu = (self.constant * dx)**2 * torch.sqrt(2 * (Sxx**2 + Syy**2 + 2 * Sxy**2))
         nu_Sxxh = torch.fft.rfftn(nu * Sxx,dim=(1,2))
         nu_Sxyh = torch.fft.rfftn(nu * Sxy,dim=(1,2))


### PR DESCRIPTION
The fft we were taking did not account for the input fields having upper/lower layers, so our off-diagonal terms were incorrect. (Unfortunately?) this does not affect the issue we have in that Arakawa+Smag low res performs the same as high res. We see the same consistency between low/high res after fixing.

![smag_fix](https://github.com/Chris-Pedersen/torch_qg/assets/16047009/f48763e1-100b-43b5-b420-277c7288bbf9)
