### PR TITLE
Spe refactor and advection fix

### DIFF
--- a/torch_qg/diagnostics.py
+++ b/torch_qg/diagnostics.py
@@ -46,6 +46,7 @@ class Diagnostics():
 
         self.diagnostics["KEspec"].append(self.get_KE_ispec())
         self.diagnostics["SPE"].append(self.get_spectral_energy_transfer())
+        self.diagnostics["SPE2"].append(self.get_spectral_energy_transfer2())
         self.diagnostics["Ensspec"].append(self.get_enstrophy_ispec())
 
     def _calc_derived_fields(self):
@@ -153,7 +154,8 @@ class Diagnostics():
         return self.get_ispec_2(self.kappa2*np.abs(self.ph)**2/self.M**2)
 
     def get_spectral_energy_transfer(self):
-        """ Return spectral energy transfer """
+        """ Return spectral energy transfer. Calculations taken from pyqg - individual terms
+            due to ke flux and ape are calculated """
 
         kef=((np.real(self.del1*self.ph[0]*np.conj(self.Jpxi[0])) + np.real(self.del2*self.ph[1]*np.conj(self.Jpxi[1])))/self.M**2)
         ape=(self.rd**-2*self.del1*self.del2*np.real((self.ph[0]-self.ph[1])*np.conj(self.Jptpc))/self.M**2)
@@ -167,6 +169,15 @@ class Diagnostics():
             spec_trans+=paramspec
 
         return -self.get_ispec_1(spec_trans)
+
+    def get_spectral_energy_transfer2(self):
+        """ Return spectral energy transfer:
+            calculate using an alternative method, just the cross-spectrum between
+            streamfunction and rhs """
+
+        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh).sum(axis=0)) / self.M**2
+
+        return self.get_ispec_1(spec_trans)
 
     def get_enstrophy_ispec(self):
         """ Get enstrophy spectrum """
@@ -230,6 +241,8 @@ class Diagnostics():
             variables["Enspec"]=(('time','lev','k1d'),np.expand_dims(self.get_aved_diagnostics("Ensspec"),axis=0),
                             { 'units': 's^-2',  'long_name': 'Enstrophy spectrum'})
             variables["SPE"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE"),axis=0),
+                            { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
+            variables["SPE2"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE"),axis=0),
                             { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
 
         global_attrs = {}

--- a/torch_qg/diagnostics.py
+++ b/torch_qg/diagnostics.py
@@ -46,7 +46,7 @@ class Diagnostics():
 
         self.diagnostics["KEspec"].append(self.get_KE_ispec())
         self.diagnostics["SPE"].append(self.get_spectral_energy_transfer())
-        self.diagnostics["SPE2"].append(self.get_spectral_energy_transfer2())
+        #self.diagnostics["SPE2"].append(self.get_spectral_energy_transfer2())
         self.diagnostics["Ensspec"].append(self.get_enstrophy_ispec())
 
     def _calc_derived_fields(self):

--- a/torch_qg/diagnostics.py
+++ b/torch_qg/diagnostics.py
@@ -175,7 +175,8 @@ class Diagnostics():
             calculate using an alternative method, just the cross-spectrum between
             streamfunction and rhs """
 
-        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh_i).sum(axis=0)) / self.M**2
+
+        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh).sum(axis=0)) / self.M**2
 
         return self.get_ispec_1(spec_trans)
 
@@ -242,7 +243,7 @@ class Diagnostics():
                             { 'units': 's^-2',  'long_name': 'Enstrophy spectrum'})
             variables["SPE"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE"),axis=0),
                             { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
-            variables["SPE2"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE"),axis=0),
+            variables["SPE2"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE2"),axis=0),
                             { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
 
         global_attrs = {}

--- a/torch_qg/diagnostics.py
+++ b/torch_qg/diagnostics.py
@@ -168,15 +168,16 @@ class Diagnostics():
             paramspec=-torch.real((self.height_ratios * torch.conj(self.ph) * self.dqh).sum(axis=0)) / self.M**2
             spec_trans+=paramspec
 
-        return -self.get_ispec_1(spec_trans)
+        return self.get_ispec_1(spec_trans)
 
     def get_spectral_energy_transfer2(self):
         """ Return spectral energy transfer:
             calculate using an alternative method, just the cross-spectrum between
             streamfunction and rhs """
 
+        rhsh=self.rhsh(self.q,self.qh,self.ph,self.u,self.v)
 
-        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh).sum(axis=0)) / self.M**2
+        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * rhsh).sum(axis=0)) / self.M**2
 
         return self.get_ispec_1(spec_trans)
 
@@ -212,7 +213,7 @@ class Diagnostics():
                         {'long_name': 'real space grid points in the x direction', 'units': 'grid point',})
         coordinates["y"] = ("y",self.y[0,:],
                         {'long_name': 'real space grid points in the y direction', 'units': 'grid point',})
-        coordinates["k1d"] = ("k1d",self.k1d,
+        coordinates["k1d"] = ("k1d",self.k1d_plot,
                         {'long_name':'1D Fourier wavenumber for isotropically averaged spectra', 'units':'m^-1'})
 
         return coordinates
@@ -243,8 +244,8 @@ class Diagnostics():
                             { 'units': 's^-2',  'long_name': 'Enstrophy spectrum'})
             variables["SPE"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE"),axis=0),
                             { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
-            variables["SPE2"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE2"),axis=0),
-                            { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
+            #variables["SPE2"]=(('time','k1d'),np.expand_dims(self.get_aved_diagnostics("SPE2"),axis=0),
+            #                { 'units': 'm^3 s^-3',  'long_name': 'Spectral energy transfer'})
 
         global_attrs = {}
         for aname in attribute_database:

--- a/torch_qg/diagnostics.py
+++ b/torch_qg/diagnostics.py
@@ -175,7 +175,7 @@ class Diagnostics():
             calculate using an alternative method, just the cross-spectrum between
             streamfunction and rhs """
 
-        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh).sum(axis=0)) / self.M**2
+        spec_trans=-torch.real((self.height_ratios * torch.conj(self.ph) * self.rhsh_i).sum(axis=0)) / self.M**2
 
         return self.get_ispec_1(spec_trans)
 

--- a/torch_qg/model.py
+++ b/torch_qg/model.py
@@ -279,7 +279,6 @@ class ArakawaModel(BaseQGModel, diagnostics.Diagnostics):
     def __init__(self,minus=1,*args,**kwargs):
         super(ArakawaModel,self).__init__(*args,**kwargs)
         self.scheme="Arakawa"
-        self.minus=minus
 
     @staticmethod
     def diffx(x,dx):
@@ -317,7 +316,7 @@ class ArakawaModel(BaseQGModel, diagnostics.Diagnostics):
         d2p=torch.fft.irfftn(-self.kappa2*ph,dim=(1,2))
         dq=torch.fft.irfftn(self.ik*qh,dim=(1,2))
         
-        rhs=self.minus*self.advect(q,p)
+        rhs=self.advect(q,p)
         rhs[0]+=(-self.betas[0]*dp[0])
         rhs[1]+=(-self.betas[1]*dp[1])
         

--- a/torch_qg/model.py
+++ b/torch_qg/model.py
@@ -338,7 +338,7 @@ class ArakawaModel(BaseQGModel, diagnostics.Diagnostics):
         ## First update q -> q_{i+1}
         rhs=self.rhs(self.q,self.qh,self.p,self.ph)
         ## Store rhsh for spectral energy transfer computation
-        self.rhsh=torch.fft.rfftn(rhs,dim=(1,2))
+        self.rhsh_i=torch.fft.rfftn(rhs,dim=(1,2))
         ## If we have no n_{i-1} timestep, we just do forward Euler
         if self.rhs_minus_one==None:
             self.q=self.q+rhs*self.dt
@@ -443,7 +443,7 @@ class PseudoSpectralModel(BaseQGModel, diagnostics.Diagnostics):
         ## First update qh -> qh_{i+1}
         rhsh=self.rhsh(self.q,self.qh,self.ph,self.u,self.v)
         ## Store rhsh for spectral energy transfer computation
-        self.rhsh=rhsh
+        self.rhsh_i=rhsh
         ## If we have no n_{i-1} timestep, we just do forward Euler
         if self.rhs_minus_one==None:
             self.qh=self.qh+rhsh*self.dt

--- a/torch_qg/model.py
+++ b/torch_qg/model.py
@@ -155,23 +155,8 @@ class BaseQGModel():
 
         ## Diagnostics are kinetic energy spectrum, spectral energy transfer, enstrophy spectrum
         self.diagnostics={"KEspec":[],
-                    "SPE":[],
-                    "SPE2":[],
+                    "SPE":[],#"SPE2":[],
                     "Ensspec":[]}
-
-        ############ ADDED FROM PYQG ###############
-        # the meridional PV gradients in each layer
-        self.Qy1 = self.beta + self.F1*(self.U1 - self.U2)
-        self.Qy2 = self.beta - self.F2*(self.U1 - self.U2)
-        self.Qy = torch.tensor([self.Qy1, self.Qy2])
-        # complex versions, multiplied by k, speeds up computations to precompute
-        self.ikQy1 = self.Qy1 * 1j * self.k
-        self.ikQy2 = self.Qy2 * 1j * self.k
-
-        # vector version
-        self.ikQy = torch.tensor(np.vstack([self.ikQy1[np.newaxis,...],
-                               self.ikQy2[np.newaxis,...]]),dtype=torch.float64)
-        self.ilQx = 0.
         
         return
     

--- a/torch_qg/model.py
+++ b/torch_qg/model.py
@@ -154,6 +154,7 @@ class BaseQGModel():
         ## Diagnostics are kinetic energy spectrum, spectral energy transfer, enstrophy spectrum
         self.diagnostics={"KEspec":[],
                     "SPE":[],
+                    "SPE2":[],
                     "Ensspec":[]}
         
         return
@@ -336,6 +337,8 @@ class ArakawaModel(BaseQGModel, diagnostics.Diagnostics):
 
         ## First update q -> q_{i+1}
         rhs=self.rhs(self.q,self.qh,self.p,self.ph)
+        ## Store rhsh for spectral energy transfer computation
+        self.rhsh=torch.fft.rfftn(rhs,dim=(1,2))
         ## If we have no n_{i-1} timestep, we just do forward Euler
         if self.rhs_minus_one==None:
             self.q=self.q+rhs*self.dt
@@ -439,6 +442,8 @@ class PseudoSpectralModel(BaseQGModel, diagnostics.Diagnostics):
 
         ## First update qh -> qh_{i+1}
         rhsh=self.rhsh(self.q,self.qh,self.ph,self.u,self.v)
+        ## Store rhsh for spectral energy transfer computation
+        self.rhsh=rhsh
         ## If we have no n_{i-1} timestep, we just do forward Euler
         if self.rhs_minus_one==None:
             self.qh=self.qh+rhsh*self.dt


### PR DESCRIPTION
I wanted to make sure our calculation of spectral energy transfer is correct, considering a) this is our main target metric, and b) arakawa+smag models appear to be anti-diffusive even on small scales, which is counter intuitive. [From eq E2 of Pavel's paper](https://arxiv.org/pdf/2302.07984.pdf), this is just the cross-spectrum of streamfunction and whatever rhs is being applied. Pyqg uses a more complicated decomposition into ape, and keflux, but we do not really care about this. So both as a sanity/consistency check, and also just to simplify the code, lets implement this new, more simple calculation.